### PR TITLE
Fixed optional filename bug

### DIFF
--- a/autospoof.py
+++ b/autospoof.py
@@ -33,18 +33,17 @@ p.add_argument('-j',
 p.add_argument('-f', 
               '--filename', 
               type=str, 
-              help='file attachment', 
-              required='False')
+              help='file attachment')
 args = p.parse_args()
 
 class mysmtp:
-   def __init__(self, server, port, toEmail, fromEmail, subject, filename):
+   def __init__(self, server, port, toEmail, fromEmail, subject):
        self.server = server 
        self.port = port
        self.toEmail = toEmail
        self.fromEmail = fromEmail
        self.subject = subject
-       self.filename = filename
+       self.filename = ''
 
    def send_message(self):
         
@@ -73,5 +72,7 @@ class mysmtp:
            print '[!] could not connect'
 
 
-q = mysmtp(args.server, args.port, args.to, args.From, args.subject, args.filename)
+q = mysmtp(args.server, args.port, args.to, args.From, args.subject)
+if args.filename:
+    q.filename = args.filename
 q.send_message()


### PR DESCRIPTION
Fixed bug where filename was unintentionally being required. It appears that if 'Required' is specified in the add_argument function, it is required even if you set the value to false. I also modified the mysmtp class so that filename was not part of the constructor. If it is specified in **init** there must be a value passed in when the object is created. I created a filename attribute, but set it to null at object creation. There is a conditional towards that bottom that checks if there was a filename passed in. If there was, it updates the filename attribute which in turn will activate the conditional inside of send_message that actually attaches the file. Specifying a filename upon executing the script will attach the file, if no filename is specified a message will be sent without an attachment.
